### PR TITLE
Introduce caching of images

### DIFF
--- a/src/Spryker/Zed/ProductPageSearch/Business/Expander/ProductConcretePageSearchExpander.php
+++ b/src/Spryker/Zed/ProductPageSearch/Business/Expander/ProductConcretePageSearchExpander.php
@@ -14,6 +14,9 @@ use Spryker\Zed\ProductPageSearch\Dependency\Facade\ProductPageSearchToProductIm
 
 class ProductConcretePageSearchExpander implements ProductConcretePageSearchExpanderInterface
 {
+    /**
+     * @var array<int, array<\Generated\Shared\Transfer\ProductImageSetTransfer>>
+     */
     protected static array $imageSetCollectionsResolved = [];
 
     /**
@@ -43,12 +46,7 @@ class ProductConcretePageSearchExpander implements ProductConcretePageSearchExpa
 
         $images = [];
 
-        if (!array_key_exists($productConcretePageSearchTransfer->getFkProduct(), static::$imageSetCollectionsResolved)) {
-            static::$imageSetCollectionsResolved[$productConcretePageSearchTransfer->getFkProduct()] = $this->productImageFacade
-                ->getProductImagesSetCollectionByProductId($productConcretePageSearchTransfer->getFkProduct());
-        }
-
-        $productImageSetTransfers = static::$imageSetCollectionsResolved[$productConcretePageSearchTransfer->getFkProduct()];
+        $productImageSetTransfers = $this->getProductImagesSetCollectionByProductId($productConcretePageSearchTransfer->getFkProduct());
         $productImageSetTransfers = $this->productImageFacade->resolveProductImageSetsForLocale(
             new ArrayObject($productImageSetTransfers),
             $productConcretePageSearchTransfer->getLocale(),
@@ -61,6 +59,21 @@ class ProductConcretePageSearchExpander implements ProductConcretePageSearchExpa
         $productConcretePageSearchTransfer->setImages($images);
 
         return $productConcretePageSearchTransfer;
+    }
+
+    /**
+     * @param int $idProduct
+     *
+     * @return array<\Generated\Shared\Transfer\ProductImageSetTransfer>
+     */
+    protected function getProductImagesSetCollectionByProductId(int $idProduct): array
+    {
+        if (!array_key_exists($idProduct, static::$imageSetCollectionsResolved)) {
+            static::$imageSetCollectionsResolved[$idProduct] = $this->productImageFacade
+                ->getProductImagesSetCollectionByProductId($idProduct);
+        }
+
+        return static::$imageSetCollectionsResolved[$idProduct];
     }
 
     /**

--- a/src/Spryker/Zed/ProductPageSearch/Business/Expander/ProductConcretePageSearchExpander.php
+++ b/src/Spryker/Zed/ProductPageSearch/Business/Expander/ProductConcretePageSearchExpander.php
@@ -14,6 +14,8 @@ use Spryker\Zed\ProductPageSearch\Dependency\Facade\ProductPageSearchToProductIm
 
 class ProductConcretePageSearchExpander implements ProductConcretePageSearchExpanderInterface
 {
+    protected static array $imageSetCollectionsResolved = [];
+
     /**
      * @var \Spryker\Zed\ProductPageSearch\Dependency\Facade\ProductPageSearchToProductImageFacadeInterface
      */
@@ -41,7 +43,12 @@ class ProductConcretePageSearchExpander implements ProductConcretePageSearchExpa
 
         $images = [];
 
-        $productImageSetTransfers = $this->productImageFacade->getProductImagesSetCollectionByProductId($productConcretePageSearchTransfer->getFkProduct());
+        if (!array_key_exists($productConcretePageSearchTransfer->getFkProduct(), static::$imageSetCollectionsResolved)) {
+            static::$imageSetCollectionsResolved[$productConcretePageSearchTransfer->getFkProduct()] = $this->productImageFacade
+                ->getProductImagesSetCollectionByProductId($productConcretePageSearchTransfer->getFkProduct());
+        }
+
+        $productImageSetTransfers = static::$imageSetCollectionsResolved[$productConcretePageSearchTransfer->getFkProduct()];
         $productImageSetTransfers = $this->productImageFacade->resolveProductImageSetsForLocale(
             new ArrayObject($productImageSetTransfers),
             $productConcretePageSearchTransfer->getLocale(),


### PR DESCRIPTION
Page search publishing of concretes becomes very slow and memory exhaustive when dealing with a large amount of locales.

One major reason for this is expanding with images. The expander will fetch and map all images and resolve per locale. The set of images already contains all localized images. However with the next locale all images are fetched and mapped once again. The problem grows with the amount of locales.

This PR resolves the problem by introducing a static cache for the images per concrete.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
