### PR TITLE
  Fix: AbstractProductConcretePageSearchListener::publish() calls wrong publisher

### DIFF
--- a/src/Spryker/Zed/ProductPageSearch/Communication/Plugin/Event/Listener/AbstractProductConcretePageSearchListener.php
+++ b/src/Spryker/Zed/ProductPageSearch/Communication/Plugin/Event/Listener/AbstractProductConcretePageSearchListener.php
@@ -27,7 +27,7 @@ abstract class AbstractProductConcretePageSearchListener extends AbstractPlugin 
      */
     protected function publish(array $productIdTimestampMap): void
     {
-        $this->getFacade()->publishWithTimestamp($productIdTimestampMap);
+        $this->getBusinessFactory()->createProductConcretePageSearchPublisher()->publishWithTimestamp($productIdTimestampMap);
     }
 
     /**


### PR DESCRIPTION
**Problem**

  The publish() method in AbstractProductConcretePageSearchListener incorrectly calls $this->getFacade()->publishWithTimestamp(), which routes to ProductAbstractPagePublisher instead of ProductConcretePageSearchPublisher.

  This causes concrete product IDs to be incorrectly treated as abstract product IDs, resulting in:
  - No data being written to spy_product_concrete_page_search
  - Concrete products not appearing in search results
  - Complete failure of the concrete product page search publishing process

  **Root Cause**

  The ProductPageSearchFacade::publishWithTimestamp() method was introduced in version 3.42.0 and incorrectly calls:
  $this->getFactory()->createProductAbstractPagePublisher()->publishWithTimestamps($productAbstractIdTimestampMap);

  However, for the AbstractProductConcretePageSearchListener, it should call the concrete publisher instead.

  **Solution**

  Changed the publish() method to directly use the ProductConcretePageSearchPublisher via the business factory, consistent with how the unpublish() method is already implemented:

  // Before (broken)
  $this->getFacade()->publishWithTimestamp($productIdTimestampMap);

  // After (fixed)
  $this->getBusinessFactory()->createProductConcretePageSearchPublisher()->publishWithTimestamp($productIdTimestampMap);

  This matches the pattern already used in the unpublish() method of the same class.

  **Impact**

  - Affected versions: 3.42.0+
  - Severity: Critical - Concrete product search publishing is completely broken